### PR TITLE
Fix/auth token flexibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ gem 'grape-active_model_serializers', '~> 1.3.2'
 gem 'grape-swagger'
 
 # Miscellaneous
-gem 'attr_encrypted', '~> 1.4.0'
+gem 'attr_encrypted', '~> 3.1.0'
 gem 'rack-cors', require: 'rack/cors'
 gem 'ci_reporter'
 gem 'require_all', '>=1.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,8 @@ GEM
       tzinfo (~> 1.1)
     arel (6.0.3)
     ast (2.3.0)
-    attr_encrypted (1.4.0)
-      encryptor (~> 1.3.0)
+    attr_encrypted (3.1.0)
+      encryptor (~> 3.0.0)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -84,7 +84,7 @@ GEM
     dotenv-rails (2.1.1)
       dotenv (= 2.1.1)
       railties (>= 4.0, < 5.1)
-    encryptor (1.3.0)
+    encryptor (3.0.0)
     enumerable-lazy (0.0.1)
     equalizer (0.0.11)
     erubi (1.8.0)
@@ -270,7 +270,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.9.0)
-  attr_encrypted (~> 1.4.0)
+  attr_encrypted (~> 3.1.0)
   better_errors
   byebug
   ci_reporter

--- a/app/api/authentication_api.rb
+++ b/app/api/authentication_api.rb
@@ -1,7 +1,7 @@
 require 'grape'
 require 'user_serializer'
 require 'json/jwt'
-
+ 
 module Api
   #
   # Provides the authentication API for Doubtfire.
@@ -162,15 +162,16 @@ module Api
       #
       desc 'Get user details from an authentication token'
       params do
-        requires :auth_token, type: String, desc: 'The user\'s temporary auth token'
+        requires :username, type: String, in: header, desc: 'The user\'s username'
+        requires :auth_token, type: String, in: header, desc: 'The user\'s temporary auth token'
       end
       post '/auth' do
-        error!({ error: 'Invalid token.' }, 404) if params[:auth_token].nil?
+        error!({ error: 'Invalid token.' }, 404) if headers['Auth-Token'].nil?
         logger.info "Get user via auth_token from #{request.ip}"
 
         # Authenticate that the token is okay
         if authenticated?
-          token = AuthToken.find_by_auth_token(params[:auth_token])
+          token = AuthToken.find_by_auth_token(headers['Auth-Token'])
           error!({ error: 'Invalid token.' }, 404) if token.nil?
           
           user = token.user

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -8,6 +8,9 @@ class AuthToken < ActiveRecord::Base
   attr_encrypted :auth_token,
     key: Doubtfire::Application.secrets.secret_key_attr,
     encode: true,
+    algorithm: 'aes-256-cbc', 
+    mode: :single_iv_and_salt, 
+    insecure_mode: true,
     attribute: 'authentication_token'
 
   def self.generate(user, remember, expiry_time = Time.zone.now + 2.hours)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,9 @@ class User < ActiveRecord::Base
   attr_encrypted :auth_token,
                  key: Doubtfire::Application.secrets.secret_key_attr,
                  encode: true,
+                 algorithm: 'aes-256-cbc', 
+                 mode: :single_iv_and_salt, 
+                 insecure_mode: true,
                  attribute: 'authentication_token'
 
   # User authentication config

--- a/db/migrate/20200528072515_add_initialization_vector_to_auth_tokens.rb
+++ b/db/migrate/20200528072515_add_initialization_vector_to_auth_tokens.rb
@@ -1,0 +1,8 @@
+class AddInitializationVectorToAuthTokens < ActiveRecord::Migration
+  def up
+  	add_column	:auth_tokens, :encrypted_authentication_token_iv, null: false, :string
+  end
+  def down
+  	remove_column	:auth_tokens, :encrypted_authentication_token_iv
+  end
+end

--- a/db/migrate/20200528075434_rename_authentication_token_to_encrypted_authentication_token.rb
+++ b/db/migrate/20200528075434_rename_authentication_token_to_encrypted_authentication_token.rb
@@ -1,0 +1,8 @@
+class RenameAuthenticationTokenToEncryptedAuthenticationToken < ActiveRecord::Migration
+  def up
+  	rename_column	:auth_tokens, :authentication_token, :encrypted_authentication_token
+  end
+  def down
+  	rename_column	:auth_tokens, :encrypted_authentication_token, :authentication_token 
+  end
+end


### PR DESCRIPTION
# Description

- The auth_token and username are moved to header of http request
- The encrypted_attr gem file is updated to version 3.1.0
- The GRAPE API endpoints are changed to fit with above changes

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Swagger UI
- [x] Postman

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if appropriate
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have created or extended unit tests to address my new additions
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

If you have any questions, please contact @macite or @jakerenzella.
